### PR TITLE
Fixed formatting in text for Types section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ bye bhai
 ```
 
 <h3 align="center">Types</h3>
-<p align="center">Numbers and strings are like other languages. Null values can be denoted using <code>nalla. sahi and galat</code> are the boolean values.</p>
+<p align="center">Numbers and strings are like other languages. Null values can be denoted using <code>nalla</code>. <code>sahi</code> and <code>galat</code> are the boolean values.</p>
 
 ```
 


### PR DESCRIPTION
Fixed code formatting for `nalla`, `sahi` and `galat` in the Types section description in README.md

Previously - 
<img width="892" alt="Screenshot 2022-03-13 at 12 27 52 PM" src="https://user-images.githubusercontent.com/11256955/158048960-eafcb855-d341-4d35-8042-c228154de2f6.png">

After the fix -
<img width="892" alt="Screenshot 2022-03-13 at 12 28 22 PM" src="https://user-images.githubusercontent.com/11256955/158048963-fb5a695e-61a9-402f-8655-01211b919f78.png">

