### PR TITLE
fix: bhaiLangSpec - fixed sahi and galat regex

### DIFF
--- a/packages/parser/src/constants/bhaiLangSpec.ts
+++ b/packages/parser/src/constants/bhaiLangSpec.ts
@@ -92,8 +92,8 @@ export const SPEC = [
   { regex: /^-?\d+/, tokenType: TokenTypes.NUMBER_TYPE },
 
   // Boolean
-  { regex: /^sahi/, tokenType: TokenTypes.BOOLEAN_TYPE },
-  { regex: /^galat/, tokenType: TokenTypes.BOOLEAN_TYPE },
+  { regex: /^\bsahi\b/, tokenType: TokenTypes.BOOLEAN_TYPE },
+  { regex: /^\bgalat\b/, tokenType: TokenTypes.BOOLEAN_TYPE },
 
   // Identifier
   { regex: /^\w+/, tokenType: TokenTypes.IDENTIFIER_TYPE },

--- a/packages/parser/test/integration/positiveTestsHelper.ts
+++ b/packages/parser/test/integration/positiveTestsHelper.ts
@@ -449,6 +449,24 @@ export const ExpressionsTests = [
       `,
     output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"VariableStatement","declarations":[{"type":"VariableDeclaration","id":{"type":"IdentifierExpression","name":"a"},"init":{"type":"LogicalExpression","operator":"||","left":{"type":"IdentifierExpression","name":"b"},"right":{"type":"IdentifierExpression","name":"d"}}}]}]}}`,
   },
+  {
+    name: `identifier name starting with "sahi", should success`,
+    input: `
+      hi bhai
+      bhai ye hai sahiValue = sahi;
+      bye bhai
+    `,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"VariableStatement","declarations":[{"type":"VariableDeclaration","id":{"type":"IdentifierExpression","name":"sahiValue"},"init":{"type":"BooleanLiteral","value":"sahi"}}]}]}}`,
+  },
+  {
+    name: `identifier name starting with "galat", should success`,
+    input: `
+      hi bhai
+      bhai ye hai galatValue = 10;
+      bye bhai
+    `,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"VariableStatement","declarations":[{"type":"VariableDeclaration","id":{"type":"IdentifierExpression","name":"galatValue"},"init":{"type":"NumericLiteral","value":10}}]}]}}`,
+  },
 ];
 
 export const IfStatementTests = [
@@ -548,9 +566,6 @@ export const IfStatementTests = [
   },
 ];
 
-
-
-
 export const WhileStatementTests = [
   {
     name: "while statement success test: only if",
@@ -617,5 +632,5 @@ export const WhileStatementTests = [
     bye bhai;
       `,
     output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"WhileStatement","test":{"type":"BinaryExpression","operator":">","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":9}},"body":{"type":"BlockStatement","body":[{"type":"ContinueStatement"},{"type":"EmptyStatement"}]}},{"type":"VariableStatement","declarations":[{"type":"VariableDeclaration","id":{"type":"IdentifierExpression","name":"a"},"init":{"type":"NumericLiteral","value":90}}]}]}}`,
-  }
-]
+  },
+];


### PR DESCRIPTION
## Tasks

- [ ] Run formater
  formatting the repo would result in 104 file changes 🙁
- [x] Run tests
  
## Context

Try this code in bhai lang playground
```bhai-lang
hi bhai
  bhai ye hai sahiValue = sahi;
  bhai ye hai galatValue = 10;
bye bhai
```

Now bhai is mad because he thinks `sahiValue` is the literal boolean value `sahi` and not as an identifier. Same thing occurs with `galat`
These line in the spec are to blame
https://github.com/DulLabs/bhai-lang/blob/10e6b024f057316b0f97305bdc460f46201ceb19/packages/parser/src/constants/bhaiLangSpec.ts#L95-L96

Unlike all the other keywords, the flanked `\b` are missing in regex and they match on any token starting with `sahi` / `galat` instead of matching on the word `sahi` / `galat`. Refer to this [\b assertion](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Assertions#boundary-type_assertions)

I have also added couple of tests (examples mentioned above are the tests)