### PR TITLE
feat: Add support for if-else-if ladders in bhailang - #214

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 
 # turbo
 .turbo
+
+# history vscode extension
+.history/

--- a/README.md
+++ b/README.md
@@ -110,17 +110,19 @@ bye bhai
 ```
 
 <h3 align="center">Conditionals</h3>
-<p align="center">Bhailang supports simple if else construct , <code>agar bhai</code> block will execute if condition is <code>sahi</code> and <code>warna bhai</code> block will execute if condition is <code>galat</code>.</p>
+<p align="center">Bhailang supports if-else-if ladder construct , <code>agar bhai</code> block will execute if condition is <code>sahi</code>, otherwise one of the subsequently added <code>nahi to bhai</code> blocks will execute if their respective condition is <code>sahi</code>, and the <code>warna bhai</code> block will eventually execute if all of the above conditions are <code>galat</code>
 
 ```
 
 hi bhai
   bhai ye hai a = 10;
-  agar bhai (a < 25) {
-   bol bhai "a is less than 25";
-  } warna bhai {
-   bol bhai "a is greater than or equal to 25";
-  }
+  agar bhai (a < 20) {
+    bol bhai "a is less than 20";
+  } nahi to bhai ( a < 25 ) {
+    bol bhai "a is less than 25";
+  } warna bhai {
+    bol bhai "a is greater than or equal to 25";
+  }
 bye bhai
 ```
 

--- a/apps/docs/components/Code/index.tsx
+++ b/apps/docs/components/Code/index.tsx
@@ -18,8 +18,10 @@ hi bhai
   jab tak bhai (b < 5) {
     bol bhai b;
 
-    agar bhai (b == a){
+    agar bhai (b == a) {
       bol bhai "b is equal to a";
+    } nahi to bhai (b == 0) {
+      bol bhai "b is equal to zero";
     }
 
     b += 1;

--- a/apps/docs/components/Documentation/index.tsx
+++ b/apps/docs/components/Documentation/index.tsx
@@ -84,12 +84,14 @@ bye bhai
     name: "Conditionals",
     description: (
       <>
-        Bhailang supports simple if else construct , <code className="language-cpp">agar bhai</code> block will execute if condition is <code className="language-cpp">sahi</code> and <code className="language-cpp">warna bhai</code> block will execute if condition is <code className="language-cpp">galat</code>.
+        Bhailang supports if-else-if ladder construct , <code className="language-cpp">agar bhai</code> block will execute if condition is <code className="language-cpp">sahi</code>, otherwise one of the subsequently added <code className="language-cpp">nahi to bhai</code> blocks will execute if their respective condition is <code className="language-cpp">sahi</code>, and the <code className="language-cpp">warna bhai</code> block will eventually execute if all of the above conditions are <code className="language-cpp">galat</code>.
       </>
     ),
     code: `hi bhai
     bhai ye hai a = 10;
-    agar bhai (a < 25) {
+    agar bhai (a < 20) {
+      bol bhai "a is less than 20";
+    } nahi to bhai ( a < 25 ) {
       bol bhai "a is less than 25";
     } warna bhai {
       bol bhai "a is greater than or equal to 25";

--- a/apps/docs/components/common/syntax.ts
+++ b/apps/docs/components/common/syntax.ts
@@ -18,7 +18,7 @@ export const bhaiLangSyntax = languages.extend("clike", {
     pattern: /(["'])((?:\\\1|(?:(?!\1)).)*)(\1)/,
     greedy: true,
   },
-  keyword: /\b(?:hi bhai|bye bhai|bol bhai|bhai ye hai|nalla|agar bhai|warna bhai|jab tak bhai|bas kar bhai|agla dekh bhai)\b/,
+  keyword: /\b(?:hi bhai|bye bhai|bol bhai|bhai ye hai|nalla|agar bhai|nahi to bhai|warna bhai|jab tak bhai|bas kar bhai|agla dekh bhai)\b/,
   boolean: /\b(?:sahi|galat)\b/,
   number: /(?:(?:\b\d+(?:\.\d*)?|\B\.\d+)(?:e[-+]?\d+)?)i?/i,
   operator:

--- a/packages/interpreter/src/components/visitor/ifStatement.ts
+++ b/packages/interpreter/src/components/visitor/ifStatement.ts
@@ -6,28 +6,44 @@ import Scope from "../scope";
 
 
 export default class IfStatement implements Visitor {
+
+  private evaluateNode(node: ASTNode | undefined, parentScope: Scope) {
+    if (node) {
+      InterpreterModule.setCurrentScope(new Scope(parentScope));
+      InterpreterModule.getCurrentScope().setLoop(parentScope.isLoop());
+      InterpreterModule.getVisitor(node.type).visitNode(node);
+    }
+  }
+
   visitNode(node: ASTNode) {
     const test = node.test;
     const parentScope = InterpreterModule.getCurrentScope();
     if (test) {
       const testResult = InterpreterModule.getVisitor(test.type).visitNode(test);
       if (testResult === true || testResult === "sahi") {
-        const consequent = node.consequent;
-        if (consequent) {
-          InterpreterModule.setCurrentScope(new Scope(parentScope));
-          InterpreterModule.getCurrentScope().setLoop(parentScope.isLoop());
-           InterpreterModule.getVisitor(consequent.type).visitNode(consequent);
-        }
+        this.evaluateNode(node.consequent, parentScope);
       } else {
-        const alternate = node.alternate;
-        if (alternate) {
-          InterpreterModule.setCurrentScope(new Scope(parentScope));
-          InterpreterModule.getCurrentScope().setLoop(parentScope.isLoop());
-          InterpreterModule.getVisitor(alternate.type).visitNode(alternate);
+        const alternates = node.alternates;
+        if (alternates && alternates.length > 0) {
+          for (var alternate of alternates) {
+            const alternateTest = alternate.test;
+            if (!alternateTest) {
+              // Reached the "warna bhai" node in the alternate list, simply evaluate it and break
+              this.evaluateNode(alternate, parentScope);
+              break;
+            } else {
+              // Evaluate the "test" condition of the "nahi to bhai" node
+              // If the condition is true, evaluate the node and break
+              const testResult = InterpreterModule.getVisitor(alternateTest!.type).visitNode(alternateTest);
+              if (testResult === true || testResult === "sahi") {
+                this.evaluateNode(alternate.consequent, parentScope);
+                break;
+              }
+            }
+          }
         }
       }
-    } 
-
+    }
     parentScope.setBreakStatement(InterpreterModule.getCurrentScope().isBreakStatement());
     parentScope.setContinueStatement(InterpreterModule.getCurrentScope().isContinueStatement());
 

--- a/packages/interpreter/test/integration/positiveTestsProvider.ts
+++ b/packages/interpreter/test/integration/positiveTestsProvider.ts
@@ -804,6 +804,74 @@ export const WithOutputPositiveTests = [
     `,
     output: "5",
   },
+  // else-if statement tests
+  {
+    name: `else-if statement success test - 1: if with one else-if, should success`,
+    input: `
+    hi bhai
+    agar bhai (galat) {
+      bol bhai "galat";
+    } nahi to bhai (sahi) {
+      bol bhai "sahi";
+    }
+    bye bhai;
+    `,
+    output: "sahi",
+  },
+  {
+    name: `else-if statement success test - 2: if with multiple else-ifs, should success`,
+    input: `
+    hi bhai
+    bhai ye hai x = 10;
+    agar bhai (x < 5) {
+      bol bhai "x < 5";
+    } nahi to bhai (x < 8) {
+      bol bhai "x < 8";
+    } nahi to bhai (x < 12) {
+      bol bhai "x < 12";
+    } nahi to bhai (x < 15) {
+      bol bhai "x < 15";
+    }
+    bye bhai;
+    `,
+    output: "x < 12",
+  },
+  {
+    name: `else-if statement success test - 3: nested if-else-if ladder, should success`,
+    input: `
+    hi bhai
+    bhai ye hai a = 15;
+    agar bhai (a < 0) {
+      bol bhai "a < 0";
+    } nahi to bhai (a > 0) {
+      agar bhai (a < 10) {
+        bol bhai "a < 10";
+      } nahi to bhai (a < 20) {
+        bol bhai "a < 20";
+      }
+    }
+    bye bhai
+    `,
+    output: "a < 20",
+  },
+  {
+    name: `else-if statement success test - 4: if-else-if ladder evaluating to else, should success`,
+    input: `
+    hi bhai
+    bhai ye hai x = 15;
+    agar bhai (x < 5) {
+      bol bhai "x < 5";
+    } nahi to bhai (x < 8) {
+      bol bhai "x < 8";
+    } nahi to bhai (x < 12) {
+      bol bhai "x < 12";
+    } warna bhai {
+      bol bhai "x > 12";
+    }
+    bye bhai;
+    `,
+    output: "x > 12",
+  },
   // logical expression test
   {
     name: `logical "&&" test with sahi galat, should success`,

--- a/packages/interpreter/test/integration/testRunner.test.ts
+++ b/packages/interpreter/test/integration/testRunner.test.ts
@@ -227,6 +227,29 @@ test("whileStatement test with infinite loop, should throw runtime exception aft
   expect(console.log).toHaveBeenCalledWith("bhai");
 });
 
+test("if-else ladders one after the other, should be evaluated separately", () => {
+  expect(() =>
+    interpreter.interpret(`
+    hi bhai
+    bhai ye hai x = 6;
+    agar bhai (x < 5) {
+      bol bhai "x < 5";
+    } nahi to bhai (x < 8) {
+      bol bhai "x < 8";
+    } agar bhai (x < 4) {
+      bol bhai "x < 4";
+    } warna bhai {
+      bol bhai "x > 4";
+    }
+    bye bhai;
+    
+    `)
+  ).not.toThrowError();
+
+  expect(console.log).toHaveBeenCalledWith("x < 8");
+  expect(console.log).toHaveBeenCalledWith("x > 4");
+});
+
 // test("jest", () => {
 //     interpreter.interpret(`
 //     hi bhai

--- a/packages/parser/src/components/parser/types/nodeTypes.ts
+++ b/packages/parser/src/components/parser/types/nodeTypes.ts
@@ -13,5 +13,5 @@ export type ASTNode = {
   declarations?: ASTNode[];
   test?: ASTNode;
   consequent?: ASTNode;
-  alternate?: ASTNode;
+  alternates?: ASTNode[];
 };

--- a/packages/parser/src/constants/bhaiLangSpec.ts
+++ b/packages/parser/src/constants/bhaiLangSpec.ts
@@ -13,6 +13,8 @@ export const TokenTypes = {
 
   WARNA_BHAI: "warna bhai",
 
+  NAHI_TO_BHAI: "nahi to bhai",
+
   JAB_TAK_BHAI: "jab tak bhai",
 
   BAS_KAR_BHAI: "bas kar bhai",
@@ -82,6 +84,7 @@ export const SPEC = [
   { regex: /^\bbol bhai\b/, tokenType: TokenTypes.BOL_BHAI_TYPE },
   { regex: /^\bbhai ye hai\b/, tokenType: TokenTypes.BHAI_YE_HAI_TYPE },
   { regex: /^\bagar bhai\b/, tokenType: TokenTypes.AGAR_BHAI },
+  { regex: /^\bnahi to bhai\b/, tokenType: TokenTypes.NAHI_TO_BHAI },
   { regex: /^\bwarna bhai\b/, tokenType: TokenTypes.WARNA_BHAI },
   { regex: /^\bnalla\b/, tokenType: TokenTypes.NALLA_TYPE },
   { regex: /^\bjab tak bhai\b/, tokenType: TokenTypes.JAB_TAK_BHAI },

--- a/packages/parser/src/module/bhaiLangModule.ts
+++ b/packages/parser/src/module/bhaiLangModule.ts
@@ -119,7 +119,7 @@ export default class BhaiLangModule {
 
   static getIfStatement() {
     if (!this._ifStatement) {
-      this._ifStatement = new IfStatement(this.getTokenExecutor(), this.getNullLiteral());
+      this._ifStatement = new IfStatement(this.getTokenExecutor());
     }
 
     return this._ifStatement;

--- a/packages/parser/test/integration/negativeTestsHelper.ts
+++ b/packages/parser/test/integration/negativeTestsHelper.ts
@@ -333,6 +333,75 @@ export const IfStatementNagativeTests = [
       `,
     output: SyntaxError,
   },
+  {
+    name: "Else-if statement test - else-if ladder without if condition first , should throw an exception",
+    input: `
+        hi bhai
+        nahi to bhai (sahi) {
+        }
+        bye bhai;
+      `,
+    output: SyntaxError,
+  },
+  {
+    name: "Else-if statement test - else-if ladder with multiple levels without if condition first , should throw an exception",
+    input: `
+        hi bhai
+        nahi to bhai (sahi) {
+        } nahi to bhai (sahi) {
+        }
+        bye bhai;
+      `,
+    output: SyntaxError,
+  },
+  {
+    name: "Else-if statement test - nothing after else-if ladder , should throw an exception",
+    input: `
+        hi bhai
+        agar bhai (sahi) {
+
+        } nahi to bhai (sahi)
+        bye bhai;
+      `,
+    output: SyntaxError,
+  },
+  {
+    name: "Else-if statement test - nothing after else-if ladder with multiple levels , should throw an exception",
+    input: `
+        hi bhai
+        agar bhai (sahi) {
+
+        } nahi to bhai (sahi) {
+
+        } nahi to bhai (sahi)
+        bye bhai;
+      `,
+    output: SyntaxError,
+  },
+  {
+    name: "Else-if statement test - else-if without a condition , should throw an exception",
+    input: `
+        hi bhai
+        agar bhai (sahi) {
+
+        } nahi to bhai
+        bye bhai;
+      `,
+    output: SyntaxError,
+  },
+  {
+    name: "Else-if statement test - else-if without a condition, multple levels , should throw an exception",
+    input: `
+        hi bhai
+        agar bhai (sahi) {
+
+        } nahi to bhai (sahi) {
+
+        } nahi to bhai
+        bye bhai;
+      `,
+    output: SyntaxError,
+  }
 ];
 
 export const ContinueStatementNegativeTests = [

--- a/packages/parser/test/integration/positiveTestsHelper.ts
+++ b/packages/parser/test/integration/positiveTestsHelper.ts
@@ -401,7 +401,7 @@ export const ExpressionsTests = [
         agar bhai (sahi && galat);
         bye bhai;
       `,
-    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"IfStatement","test":{"type":"LogicalExpression","operator":"&&","left":{"type":"BooleanLiteral","value":"sahi"},"right":{"type":"BooleanLiteral","value":"galat"}},"consequent":{"type":"EmptyStatement"},"alternate":{"type":"NullLiteral","value":"nalla"}}]}}`,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"IfStatement","test":{"type":"LogicalExpression","operator":"&&","left":{"type":"BooleanLiteral","value":"sahi"},"right":{"type":"BooleanLiteral","value":"galat"}},"consequent":{"type":"EmptyStatement"},"alternates":[]}]}}`,
   },
   {
     name: `logical "&&" test with expression, should success`,
@@ -410,7 +410,7 @@ export const ExpressionsTests = [
         agar bhai (a + b && d);
         bye bhai;
       `,
-    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"IfStatement","test":{"type":"LogicalExpression","operator":"&&","left":{"type":"BinaryExpression","operator":"+","left":{"type":"IdentifierExpression","name":"a"},"right":{"type":"IdentifierExpression","name":"b"}},"right":{"type":"IdentifierExpression","name":"d"}},"consequent":{"type":"EmptyStatement"},"alternate":{"type":"NullLiteral","value":"nalla"}}]}}`,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"IfStatement","test":{"type":"LogicalExpression","operator":"&&","left":{"type":"BinaryExpression","operator":"+","left":{"type":"IdentifierExpression","name":"a"},"right":{"type":"IdentifierExpression","name":"b"}},"right":{"type":"IdentifierExpression","name":"d"}},"consequent":{"type":"EmptyStatement"},"alternates":[]}]}}`,
   },
   {
     name: `logical "&&" test in variable declaration, should success`,
@@ -429,7 +429,7 @@ export const ExpressionsTests = [
         agar bhai (sahi || galat);
         bye bhai;
       `,
-    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"IfStatement","test":{"type":"LogicalExpression","operator":"||","left":{"type":"BooleanLiteral","value":"sahi"},"right":{"type":"BooleanLiteral","value":"galat"}},"consequent":{"type":"EmptyStatement"},"alternate":{"type":"NullLiteral","value":"nalla"}}]}}`,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"IfStatement","test":{"type":"LogicalExpression","operator":"||","left":{"type":"BooleanLiteral","value":"sahi"},"right":{"type":"BooleanLiteral","value":"galat"}},"consequent":{"type":"EmptyStatement"},"alternates":[]}]}}`,
   },
   {
     name: `logical "||" test with expression, should success`,
@@ -438,7 +438,7 @@ export const ExpressionsTests = [
         agar bhai (a + b || d);
         bye bhai;
       `,
-    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"IfStatement","test":{"type":"LogicalExpression","operator":"||","left":{"type":"BinaryExpression","operator":"+","left":{"type":"IdentifierExpression","name":"a"},"right":{"type":"IdentifierExpression","name":"b"}},"right":{"type":"IdentifierExpression","name":"d"}},"consequent":{"type":"EmptyStatement"},"alternate":{"type":"NullLiteral","value":"nalla"}}]}}`,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"IfStatement","test":{"type":"LogicalExpression","operator":"||","left":{"type":"BinaryExpression","operator":"+","left":{"type":"IdentifierExpression","name":"a"},"right":{"type":"IdentifierExpression","name":"b"}},"right":{"type":"IdentifierExpression","name":"d"}},"consequent":{"type":"EmptyStatement"},"alternates":[]}]}}`,
   },
   {
     name: `logical "||" test in variable declaration, should success`,
@@ -478,7 +478,7 @@ export const IfStatementTests = [
     }
     bye bhai;
       `,
-    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]},"alternate":{"type":"NullLiteral","value":"nalla"}}]}}`,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]},"alternates":[]}]}}`,
   },
   {
     name: "if statement success test - 2: if else both",
@@ -490,7 +490,7 @@ export const IfStatementTests = [
     }
     bye bhai;
       `,
-    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]},"alternate":{"type":"BlockStatement","body":[]}}]}}`,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]},"alternates":[{"type":"BlockStatement","body":[]}]}]}}`,
   },
   {
     name: "if statement success test - 3: if only with comarison condn",
@@ -502,7 +502,7 @@ export const IfStatementTests = [
     } 
     bye bhai;
       `,
-    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"VariableStatement","declarations":[{"type":"VariableDeclaration","id":{"type":"IdentifierExpression","name":"x"},"init":{"type":"NumericLiteral","value":9}}]},{"type":"IfStatement","test":{"type":"BinaryExpression","operator":">=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":9}},"consequent":{"type":"BlockStatement","body":[{"type":"ExpressionStatement","expression":{"type":"AssignmentExpression","operator":"=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":5}}}]},"alternate":{"type":"NullLiteral","value":"nalla"}}]}}`,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"VariableStatement","declarations":[{"type":"VariableDeclaration","id":{"type":"IdentifierExpression","name":"x"},"init":{"type":"NumericLiteral","value":9}}]},{"type":"IfStatement","test":{"type":"BinaryExpression","operator":">=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":9}},"consequent":{"type":"BlockStatement","body":[{"type":"ExpressionStatement","expression":{"type":"AssignmentExpression","operator":"=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":5}}}]},"alternates":[]}]}}`,
   },
   {
     name: "if statement success test - 4: if only with equality condn",
@@ -514,7 +514,7 @@ export const IfStatementTests = [
     } 
     bye bhai;
       `,
-    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"VariableStatement","declarations":[{"type":"VariableDeclaration","id":{"type":"IdentifierExpression","name":"x"},"init":{"type":"NumericLiteral","value":9}}]},{"type":"IfStatement","test":{"type":"BinaryExpression","operator":"==","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":9}},"consequent":{"type":"BlockStatement","body":[{"type":"ExpressionStatement","expression":{"type":"AssignmentExpression","operator":"=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":5}}}]},"alternate":{"type":"NullLiteral","value":"nalla"}}]}}`,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"VariableStatement","declarations":[{"type":"VariableDeclaration","id":{"type":"IdentifierExpression","name":"x"},"init":{"type":"NumericLiteral","value":9}}]},{"type":"IfStatement","test":{"type":"BinaryExpression","operator":"==","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":9}},"consequent":{"type":"BlockStatement","body":[{"type":"ExpressionStatement","expression":{"type":"AssignmentExpression","operator":"=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":5}}}]},"alternates":[]}]}}`,
   },
   {
     name: "if statement success test - 4: if only with equality condn",
@@ -526,7 +526,7 @@ export const IfStatementTests = [
     } 
     bye bhai;
       `,
-    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"VariableStatement","declarations":[{"type":"VariableDeclaration","id":{"type":"IdentifierExpression","name":"x"},"init":{"type":"NumericLiteral","value":9}}]},{"type":"IfStatement","test":{"type":"BinaryExpression","operator":"==","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":9}},"consequent":{"type":"BlockStatement","body":[{"type":"ExpressionStatement","expression":{"type":"AssignmentExpression","operator":"=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":5}}}]},"alternate":{"type":"NullLiteral","value":"nalla"}}]}}`,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"VariableStatement","declarations":[{"type":"VariableDeclaration","id":{"type":"IdentifierExpression","name":"x"},"init":{"type":"NumericLiteral","value":9}}]},{"type":"IfStatement","test":{"type":"BinaryExpression","operator":"==","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":9}},"consequent":{"type":"BlockStatement","body":[{"type":"ExpressionStatement","expression":{"type":"AssignmentExpression","operator":"=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":5}}}]},"alternates":[]}]}}`,
   },
   {
     name: "if statement success test - 5: if only with inequality condn",
@@ -538,7 +538,7 @@ export const IfStatementTests = [
     } 
     bye bhai;
       `,
-    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"VariableStatement","declarations":[{"type":"VariableDeclaration","id":{"type":"IdentifierExpression","name":"x"},"init":{"type":"NumericLiteral","value":9}}]},{"type":"IfStatement","test":{"type":"BinaryExpression","operator":"!=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":9}},"consequent":{"type":"BlockStatement","body":[{"type":"ExpressionStatement","expression":{"type":"AssignmentExpression","operator":"=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":5}}}]},"alternate":{"type":"NullLiteral","value":"nalla"}}]}}`,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"VariableStatement","declarations":[{"type":"VariableDeclaration","id":{"type":"IdentifierExpression","name":"x"},"init":{"type":"NumericLiteral","value":9}}]},{"type":"IfStatement","test":{"type":"BinaryExpression","operator":"!=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":9}},"consequent":{"type":"BlockStatement","body":[{"type":"ExpressionStatement","expression":{"type":"AssignmentExpression","operator":"=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":5}}}]},"alternates":[]}]}}`,
   },
   {
     name: "if statement success test - 6: else with only expression statement",
@@ -550,7 +550,7 @@ export const IfStatementTests = [
     } warna bhai (x >= 9);
     bye bhai;
       `,
-    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"VariableStatement","declarations":[{"type":"VariableDeclaration","id":{"type":"IdentifierExpression","name":"x"},"init":{"type":"NumericLiteral","value":9}}]},{"type":"IfStatement","test":{"type":"BinaryExpression","operator":"!=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":9}},"consequent":{"type":"BlockStatement","body":[{"type":"ExpressionStatement","expression":{"type":"AssignmentExpression","operator":"=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":5}}}]},"alternate":{"type":"ExpressionStatement","expression":{"type":"BinaryExpression","operator":">=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":9}}}}]}}`,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"VariableStatement","declarations":[{"type":"VariableDeclaration","id":{"type":"IdentifierExpression","name":"x"},"init":{"type":"NumericLiteral","value":9}}]},{"type":"IfStatement","test":{"type":"BinaryExpression","operator":"!=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":9}},"consequent":{"type":"BlockStatement","body":[{"type":"ExpressionStatement","expression":{"type":"AssignmentExpression","operator":"=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":5}}}]},"alternates":[{"type":"ExpressionStatement","expression":{"type":"BinaryExpression","operator":">=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":9}}}]}]}}`,
   },
   {
     name: "if statement success test - 7: with block",
@@ -562,7 +562,59 @@ export const IfStatementTests = [
     warna bhai (x >= 9);
     bye bhai;
       `,
-    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"VariableStatement","declarations":[{"type":"VariableDeclaration","id":{"type":"IdentifierExpression","name":"x"},"init":{"type":"NumericLiteral","value":9}}]},{"type":"IfStatement","test":{"type":"BinaryExpression","operator":"!=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":9}},"consequent":{"type":"ExpressionStatement","expression":{"type":"AssignmentExpression","operator":"=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":5}}},"alternate":{"type":"ExpressionStatement","expression":{"type":"BinaryExpression","operator":">=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":9}}}}]}}`,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"VariableStatement","declarations":[{"type":"VariableDeclaration","id":{"type":"IdentifierExpression","name":"x"},"init":{"type":"NumericLiteral","value":9}}]},{"type":"IfStatement","test":{"type":"BinaryExpression","operator":"!=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":9}},"consequent":{"type":"ExpressionStatement","expression":{"type":"AssignmentExpression","operator":"=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":5}}},"alternates":[{"type":"ExpressionStatement","expression":{"type":"BinaryExpression","operator":">=","left":{"type":"IdentifierExpression","name":"x"},"right":{"type":"NumericLiteral","value":9}}}]}]}}`,
+  },
+  {
+    name: "else-if statement success test - 1: if-else-if one level ladder",
+    input: `
+    hi bhai
+    agar bhai (sahi) {
+    } nahi to bhai (sahi) {
+    }
+    bye bhai;
+      `,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]},"alternates":[{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]}}]}]}}`
+  },
+  {
+    name: "else-if statement success test - 2: if-else-if one level ladder with else",
+    input: `
+    hi bhai
+    agar bhai (sahi) {
+    } nahi to bhai (sahi) {
+    } warna bhai {
+    }
+    bye bhai;
+      `,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]},"alternates":[{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]}},{"type":"BlockStatement","body":[]}]}]}}`
+  },
+  {
+    name: "else-if statement success test - 3: if-else-if multiple levels ladder",
+    input: `
+    hi bhai
+    agar bhai (sahi) {
+    } nahi to bhai (sahi) {
+    } nahi to bhai (sahi) {
+    } nahi to bhai (sahi) {
+    } nahi to bhai (sahi) {
+    }
+    bye bhai;
+      `,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]},"alternates":[{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]}},{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]}},{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]}},{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]}}]}]}}`
+  },
+  {
+    name: "else-if statement success test - 4: if-else-if multiple levels ladder with else",
+    input: `
+    hi bhai
+    agar bhai (sahi) {
+    } nahi to bhai (sahi) {
+    } nahi to bhai (sahi) {
+    } nahi to bhai (sahi) {
+    } nahi to bhai (sahi) {
+    } warna bhai {
+    }
+    bye bhai;
+      `,
+    output: `{"type":"Program","body":{"type":"InitStatement","body":[{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]},"alternates":[{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]}},{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]}},{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]}},{"type":"IfStatement","test":{"type":"BooleanLiteral","value":"sahi"},"consequent":{"type":"BlockStatement","body":[]}},{"type":"BlockStatement","body":[]}]}]}}`
   },
 ];
 


### PR DESCRIPTION
This PR closes issue #214 by adding support for if-else-if ladders

Example: 
`
hi bhai
bhai ye hai x = 10;
    agar bhai (x < 5) {
      bol bhai "x < 5";
    } nahi to bhai (x < 8) {
      bol bhai "x < 8";
    } nahi to bhai (x < 12) {
      bol bhai "x < 12";
    } nahi to bhai (x < 15) {
      bol bhai "x < 15";
    }
  bye bhai;
`

Output:
`
x < 12
`